### PR TITLE
Fixed `xfsm_header_fields` error

### DIFF
--- a/SW-FB/xfsm.h
+++ b/SW-FB/xfsm.h
@@ -78,7 +78,7 @@ typedef enum {
 #define NUM_HDR_FIELDS 28
 
 
-const struct xfsm_hdr_fields {
+extern const struct xfsm_hdr_fields {
     hdr_fields type;
     const char *name;
     size_t len;

--- a/XL-toolchain/pom.xml
+++ b/XL-toolchain/pom.xml
@@ -77,11 +77,21 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.9.6</version>
-        </dependency>
+         </dependency>
+	 <dependency>
+	    <groupId>javax.xml.bind</groupId>
+  	    <artifactId>jaxb-api</artifactId>
+  	    <version>2.3.0</version>
+      	 </dependency>
+	 <dependency>
+	    <groupId>com.sun.xml.bind</groupId>
+	    <artifactId>jaxb-core</artifactId>
+	    <version>2.3.0</version>
+	 </dependency>
+	 <dependency>
+	    <groupId>com.sun.xml.bind</groupId>
+	    <artifactId>jaxb-impl</artifactId>
+	    <version>2.3.0</version>
+	</dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
```
/usr/bin/ld: xfsm.o:/root/FlowBlaze-master/SW-FB/xfsm.h:88: multiple definition of `xfsm_header_fields'; loader.o:/root/FlowBlaze-master/SW-FB/xfsm.h:88: first defined here
/usr/bin/ld: pkt-parser.o:/root/FlowBlaze-master/SW-FB/xfsm.h:88: multiple definition of `xfsm_header_fields'; loader.o:/root/FlowBlaze-master/SW-FB/xfsm.h:88: first defined here
/usr/bin/ld: flowblaze.o:/root/FlowBlaze-master/SW-FB/xfsm.h:88: multiple definition of `xfsm_header_fields'; loader.o:/root/FlowBlaze-master/SW-FB/xfsm.h:88: first defined here
```